### PR TITLE
Restructure executor

### DIFF
--- a/executor.md
+++ b/executor.md
@@ -41,7 +41,6 @@ A any function / callable which is submitted to an executor has to be serializab
 ### TODO
 
 * The goal is to unify the two interfaces in `executorlib` to provide the caching of the `Fileexecutor` as optional feature.
-* A series of smaller nodes with similar resource requirements should be be convertable into one larger task which is then executed by `executorlib` as a single job in the queuing system, i.e. task grouping. 
 * Implement remote file handling. For example when two VASP calculation are submitted to an HPC cluster, with the second VASP calculation depending on the `WAVECAR` from the first VASP calculation. We do not want to copy the `WAVECAR` from the HPC to the workstation and then back from the workstation to the HPC. Still this level of remote file handling is currently not yet implemented in `executorlib`.
 * Update documentation of `executorlib`. Currently prototypical features like the submission to an queuing system outside the queuing system allocation are only documented as prototypical examples [pyiron-dev/remote-executor](https://github.com/pyiron-dev/remote-executor) but are not yet included in the official documentation.
 


### PR DESCRIPTION
Here I try to accomplish two things:

First, to better separate the actual minimum requirements and interface from the description of our preferred tool. In this way, `executorlib.Executor` is only one implementation of what `pyiron_workflow` requires. To this end I split appart "downstream" sections (base and workflow and what they require) and an "upstream" section (executorlib and what it offers).

Second, there is a mismatch between the `executorlib` flow management and `pyiron_workflow` flow management, which was embedded in this statement:
> * For both `pyiron_base` and `pyiron_workflow` it would be convenient if users could send the entire graph to the HPC for execution, without relying on a connection to an external process monitoring the graph as it is currently implemented in `pyiron_workflow`. This can be achieved if a series of smaller nodes with similar resource requirements can be converted into one larger task which is then executed by `executorlib` as a single job in the queuing system. So a node in `pyiron_workflow` does not have a one to one relation to an task in `executorlib`. In `executorlib` tasks are primarily defined by having similar resoruce requirements, only when a process has changing resource requirements, then it makes sense to separate them into individul tasks in `executorlib`. In the same way `executorlib` can be used to efficiently parallelize the execution.  

Which I streamlined down to a single "TODO" around task grouping for executorlib.

One issue here is that on the `pyiron_workflow` side, the nodes are all functional but the graph as a whole has state (inputs and outputs), and _after_ the node functionality is executed, a callback function is used to map the result of that functionality back onto the graph state (i.e. to populate the output channels with data). In the context of firing off the entire graph to something like SLURM all at once, I don't see an easy technical solution for holding and updating the graph state. I also don't see and easy technical solution for avoiding the graph IO updates -- `pyiron_workflow` is exactly a workflow manager and expects to be able to manage the workflow.

The second issue is that, from [a conversation with @jan-janssen](https://github.com/pyiron/specs/pull/31/files#r1789103867), my understanding is that executorlib handles the dependency trees in the following way: DAG only, each downstream can depend on multiple upstream, but each dependency must be absorbed in its entirety -- i.e. multiple-input-single-output. That is not an incompatible world to `pyiron_workflow`, but represents only a subset of the cyclic-and multiple-input-multiple-output graphs representable by `pyiron_workflow`, so we would at most be able to use this functionality on a subset of graphs.

I think this sort of dependency tree is a great feature for `executorlib`, and is absolutely useful for the "high performance expert" user case. I just want to break it apart from the universal spec. For  the `pyiron_workflow` use case, it would be much more productive to focus on the abilities to (a) run the entire graph remotely or (b) run individual nodes remotely (per @Tara-Lakshmipathy's [PR](https://github.com/pyiron/specs/pull/28)). These have the advantage that they're both already possible, so it's just a matter of building nicer users interfaces to the existing capability, e.g. in part by combining `Executor` and `FileExecutor` as already suggested here.